### PR TITLE
Updated bug_report.md to enable template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Legacy RP Bug Report Template
-about: This template is used when submitting bug reports
+name: Bug report
+about: Please be as detailed and descriptive as possible.
 title: 'Bug report'
 labels: bug
 assignees: InZidiuZ


### PR DESCRIPTION
Required fields were missing from bug_report.md. Added "name" and "about". These fields are public facing to the user, and can be seen as public facing title and public facing description. Feel free to change these values as you see fit.